### PR TITLE
fix default formatting

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -5,7 +5,7 @@ inputs:
   prepend: 
     required: false
     description: 'string that goes before the value'
-    default: '__version__="'
+    default: '__version__ = "'
   
   allow_feature_branches: 
     required: false


### PR DESCRIPTION
correct pip8 formatting is to have spaces around eq sign in variable assignment 